### PR TITLE
Removing dead Twitter Card Preview link

### DIFF
--- a/Website/Sites/webdevchecklist.com/Sections/ASP.NET/index.xml
+++ b/Website/Sites/webdevchecklist.com/Sections/ASP.NET/index.xml
@@ -215,7 +215,6 @@
     </rule>
     <rule name="Twitter Cards" optional="true">
       <link url="https://dev.twitter.com/docs/cards">Documentation</link>
-      <link url="https://dev.twitter.com/docs/cards/preview">Preview Tool</link>
     </rule>
     <rule name="Facebook Insights">
       <link url="https://developers.facebook.com/docs/insights/">Facebook Insights</link>

--- a/Website/Sites/webdevchecklist.com/Sections/Play-Framework/index.xml
+++ b/Website/Sites/webdevchecklist.com/Sections/Play-Framework/index.xml
@@ -242,7 +242,6 @@
     </rule>
     <rule name="Twitter Cards" optional="true">
       <link url="https://dev.twitter.com/docs/cards">Documentation</link>
-      <link url="https://dev.twitter.com/docs/cards/preview">Preview Tool</link>
     </rule>
     <rule name="Facebook Insights">
       <link url="https://developers.facebook.com/docs/insights/">Facebook Insights</link>

--- a/Website/Sites/webdevchecklist.com/Sections/index.xml
+++ b/Website/Sites/webdevchecklist.com/Sections/index.xml
@@ -210,7 +210,6 @@
     </rule>
     <rule name="Twitter Cards" optional="true">
       <link url="https://dev.twitter.com/docs/cards">Documentation</link>
-      <link url="https://dev.twitter.com/docs/cards/preview">Preview Tool</link>
     </rule>
     <rule name="Facebook Insights">
       <link url="https://developers.facebook.com/docs/insights/">Facebook Insights</link>


### PR DESCRIPTION
https://dev.twitter.com/docs/cards/preview does not seem to exist.
Cannot locate a replacement, and I believe it required logging into your
Twitter account anyway.